### PR TITLE
Improved rotation and image reset

### DIFF
--- a/source/chrome/content/options.js
+++ b/source/chrome/content/options.js
@@ -93,6 +93,9 @@ function imagezoom_saveOptions() {
 
   nsIPrefBranchObj.setBoolPref("reversescrollzoom", document.getElementById("imagezoomreversescroll").checked);
 
+  nsIPrefBranchObj.setIntPref("rotateKeys", document.getElementById("imagezoomrotatekeys").value);
+  nsIPrefBranchObj.setIntPref("rotateValue", document.getElementById("imagezoomrotatevalue").value);
+
   return true;
 }
 
@@ -127,6 +130,14 @@ function imagezoom_initializeOptions() {
 
   scroll = nsIPrefBranchObj.getIntPref("imageresetbutton");
   scrollValueBox = document.getElementById("imagezoomimageresetbutton");
+  scrollValueBox.selectedItem = scrollValueBox.getElementsByAttribute("value", scroll)[0];
+
+  scroll = nsIPrefBranchObj.getIntPref("rotateKeys");
+  scrollValueBox = document.getElementById("imagezoomrotatekeys");
+  scrollValueBox.selectedItem = scrollValueBox.getElementsByAttribute("value", scroll)[0];
+
+  scroll = nsIPrefBranchObj.getIntPref("rotateValue");
+  scrollValueBox = document.getElementById("imagezoomrotatevalue");
   scrollValueBox.selectedItem = scrollValueBox.getElementsByAttribute("value", scroll)[0];
 
   var zoom = nsIPrefBranchObj.getIntPref("zoomvalue");

--- a/source/chrome/content/options.xul
+++ b/source/chrome/content/options.xul
@@ -159,6 +159,42 @@
                                             <spacer flex="1" />
                                             <spacer flex="1" />
                                         </row>
+                                        <row align="center" flex="1">
+                                            <label id="imagezoomrotatekeyslabelbefore" value="Rotate Key" control="imagezoomrotatekeys"/>
+                                            <menulist id="imagezoomrotatekeys" prefstring="imagezoom.rotateKeys">
+                                                <menupopup>
+                                                    <menuitem label="&iz.options.none.label;" value="0"/>
+                                                    <menuitem label="Ctrl" value="1"/>
+                                                    <menuitem label="Alt" value="2"/>
+                                                    <menuitem label="Shift" value="4"/>
+                                                </menupopup>
+                                            </menulist>
+                                            <spacer flex="1" />
+                                            <spacer flex="1" />
+                                        </row>
+                                        <row align="center" flex="1">
+                                            <label id="imagezoomrotatevaluelabelbefore"
+                                                   value="Rotate Angle Increment"
+                                                   control="imagezoomrotatevalue"/>
+                                            <hbox align="center">
+                                                <menulist id="imagezoomrotatevalue" prefstring="imagezoom.rotateValue">
+                                                    <menupopup>
+                                                        <menuitem label="90" value="90"/>
+                                                        <menuitem label="45" value="45"/>
+                                                        <menuitem label="30" value="30"/>
+                                                        <menuitem label="15" value="15"/>
+                                                        <menuitem label="10" value="10"/>
+                                                        <menuitem label="5" value="5"/>
+                                                        <menuitem label="3" value="3"/>
+                                                        <menuitem label="2" value="2"/>
+                                                        <menuitem label="1" value="1"/>
+                                                    </menupopup>
+                                                </menulist>
+                                                <label id="imagezoomrotatevaluelabelafter" value="°"/>
+                                            </hbox>
+                                            <spacer flex="1"/>
+                                            <spacer flex="1" />
+                                        </row>
                                     </rows>
                                 </grid>
                             </hbox>

--- a/source/chrome/content/options.xul
+++ b/source/chrome/content/options.xul
@@ -160,13 +160,17 @@
                                             <spacer flex="1" />
                                         </row>
                                         <row align="center" flex="1">
-                                            <label id="imagezoomrotatekeyslabelbefore" value="Rotate Key" control="imagezoomrotatekeys"/>
+                                            <label id="imagezoomrotatekeyslabelbefore" value="&iz.options.rotatekeys.label;" control="imagezoomrotatekeys"/>
                                             <menulist id="imagezoomrotatekeys" prefstring="imagezoom.rotateKeys">
                                                 <menupopup>
                                                     <menuitem label="&iz.options.none.label;" value="0"/>
                                                     <menuitem label="Ctrl" value="1"/>
                                                     <menuitem label="Alt" value="2"/>
                                                     <menuitem label="Shift" value="4"/>
+                                                    <menuitem label="Ctrl+Alt" value="3"/>
+                                                    <menuitem label="Ctrl+Shift" value="5"/>
+                                                    <menuitem label="Alt+Shift" value="6"/>
+                                                    <menuitem label="Ctrl+Alt+Shift" value="7"/>
                                                 </menupopup>
                                             </menulist>
                                             <spacer flex="1" />
@@ -174,7 +178,7 @@
                                         </row>
                                         <row align="center" flex="1">
                                             <label id="imagezoomrotatevaluelabelbefore"
-                                                   value="Rotate Angle Increment"
+                                                   value="&iz.options.defaultrotate.label;"
                                                    control="imagezoomrotatevalue"/>
                                             <hbox align="center">
                                                 <menulist id="imagezoomrotatevalue" prefstring="imagezoom.rotateValue">
@@ -184,10 +188,6 @@
                                                         <menuitem label="30" value="30"/>
                                                         <menuitem label="15" value="15"/>
                                                         <menuitem label="10" value="10"/>
-                                                        <menuitem label="5" value="5"/>
-                                                        <menuitem label="3" value="3"/>
-                                                        <menuitem label="2" value="2"/>
-                                                        <menuitem label="1" value="1"/>
                                                     </menupopup>
                                                 </menulist>
                                                 <label id="imagezoomrotatevaluelabelafter" value="°"/>

--- a/source/chrome/content/overlay.js
+++ b/source/chrome/content/overlay.js
@@ -44,7 +44,7 @@ function ImageZoomOverlay() {
   var imagezoomBundle;
   var contextSubMenuLabel;
   var contextRotateMenuLabel;
-  var lastRotating = 0;
+  var rotateTime = 0;
 
   //Public Functions
   this.initImageZoom = function () {
@@ -553,8 +553,28 @@ function ImageZoomOverlay() {
 
     // Rotate the image by a number of degrees
     function rotate(degrees) {
-      if(new Date().getTime() - lastRotating < 300) return;
-      lastRotating = new Date().getTime();
+      if(new Date().getTime() - rotateTime < 200) return;
+      rotateTime = new Date().getTime();
+
+      if (!pImage.originalData) {
+        pImage.originalData = {
+          src: pImage.tagName.toLowerCase() === "canvas" ? pImage.getDataUrl() : pImage.src,
+          naturalWidth: pImage.naturalWidth,
+          naturalHeight: pImage.naturalHeight,
+          originalPxWidth: pImage.originalPxWidth,
+          originalPxHeight: pImage.originalPxHeight,
+          originalWidth: pImage.originalWidth,
+          originalHeight: pImage.originalHeight
+        };
+      }
+      var origData = pImage.originalData;
+
+      if (degrees < 0) {
+        degrees = (pImage.angle + 360 + (degrees % 360)) % 360;
+      }
+      else {
+        degrees = (pImage.angle + degrees) % 360;
+      }
 
       var theta;
       if (degrees >= 0) {
@@ -563,24 +583,19 @@ function ImageZoomOverlay() {
       else {
         theta = (Math.PI * (360 + degrees)) / 180;
       }
-      var costheta = Math.cos(theta);
-      var sintheta = Math.sin(theta);
+      var costheta = Math.abs(Math.cos(theta));
+      var sintheta = Math.abs(Math.sin(theta));
 
       var canvas = pImage.ownerDocument.createElement("canvas");
 
       // Set the new width of the image
-      canvas.width = Math.abs(costheta * pImage.naturalWidth) + Math.abs(sintheta * pImage.naturalHeight);
+      canvas.width = costheta * origData.naturalWidth + sintheta * origData.naturalHeight;
 
       // Set the new height of the image
-      canvas.height = Math.abs(costheta * pImage.naturalHeight) + Math.abs(sintheta * pImage.naturalWidth);
+      canvas.height = costheta * origData.naturalHeight + sintheta * origData.naturalWidth;
 
       canvas.oImage = new Image();
-
-      if (pImage.tagName.toLowerCase() === "canvas") {
-        canvas.oImage.src = pImage.toDataURL();
-      } else {
-        canvas.oImage.src = pImage.src;
-      }
+      canvas.oImage.src = origData.src;
 
       canvas.oImage.onload = function () {
 
@@ -588,38 +603,31 @@ function ImageZoomOverlay() {
         ctx.save();
 
         if (theta <= Math.PI / 2) {
-          ctx.translate(sintheta * canvas.oImage.naturalHeight, 0);
+          ctx.translate(Math.sin(theta) * canvas.oImage.naturalHeight, 0);
         }
         else if (theta <= Math.PI) {
-          ctx.translate(canvas.width, -costheta * canvas.oImage.naturalHeight);
+          ctx.translate(canvas.width, -Math.cos(theta) * canvas.oImage.naturalHeight);
         }
         else if (theta <= 1.5 * Math.PI) {
-          ctx.translate(-costheta * canvas.oImage.naturalWidth, canvas.height);
+          ctx.translate(-Math.cos(theta) * canvas.oImage.naturalWidth, canvas.height);
         }
         else {
-          ctx.translate(0, -sintheta * canvas.oImage.naturalWidth);
+          ctx.translate(0, -Math.sin(theta) * canvas.oImage.naturalWidth);
         }
 
-        var tmpOriginalPxWidth = Math.abs(costheta * pImage.originalPxWidth) + Math.abs(sintheta * pImage.originalPxHeight);
-        var tmpOriginalPxHeight = Math.abs(costheta * pImage.originalPxHeight) + Math.abs(sintheta * pImage.originalPxWidth);
-        pImage.originalPxWidth = tmpOriginalPxWidth;
-        pImage.originalPxHeight = tmpOriginalPxHeight;
-        var tmpOriginalWidth = Math.abs(costheta * pImage.originalWidth) + Math.abs(sintheta * pImage.originalHeight);
-        var tmpOriginalHeight = Math.abs(costheta * pImage.originalHeight) + Math.abs(sintheta * pImage.originalWidth);
-        pImage.originalWidth = tmpOriginalWidth;
-        pImage.originalHeight = tmpOriginalHeight;
-        var tmpStypeWidth = Math.abs(costheta * getDimInt(pImage.style.width)) + Math.abs(sintheta * getDimInt(pImage.style.height));
-        var tmpStyleHeight = Math.abs(costheta * getDimInt(pImage.style.height)) + Math.abs(sintheta * getDimInt(pImage.style.width));
-        pImage.style.width = tmpStypeWidth + getDimUnit(pImage.style.width);
-        pImage.style.height = tmpStyleHeight + getDimUnit(pImage.style.height);
+        pImage.originalPxWidth = costheta * origData.originalPxWidth + sintheta * origData.originalPxHeight;
+        pImage.originalPxHeight = costheta * origData.originalPxHeight + sintheta * origData.originalPxWidth;
+        pImage.originalWidth = costheta * origData.originalWidth + sintheta * origData.originalHeight;
+        pImage.originalHeight = costheta * origData.originalHeight + sintheta * origData.originalWidth;
 
-        if (degrees < 0) {
-          pImage.angle = (pImage.angle + 360 + (degrees % 360)) % 360;
-        }
-        else {
-          pImage.angle = (pImage.angle + degrees) % 360;
-        }
+        var t0 = Math.PI * pImage.angle / 180;
+        var natWidthT0 = Math.abs(Math.cos(t0)) * origData.naturalWidth + Math.abs(Math.sin(t0)) * origData.naturalHeight;
+        var natHeightT0 = Math.abs(Math.cos(t0)) * origData.naturalHeight + Math.abs(Math.sin(t0)) * origData.naturalWidth;
 
+        pImage.style.width = (getDimInt(pImage.style.width) * canvas.width / natWidthT0) + getDimUnit(pImage.style.width);
+        pImage.style.height = (getDimInt(pImage.style.height) * canvas.height / natHeightT0) + getDimUnit(pImage.style.height);
+
+        pImage.angle = degrees;
 
         ctx.rotate(theta);
         ctx.clearRect(0, 0, canvas.oImage.naturalWidth, canvas.oImage.naturalHeight);

--- a/source/chrome/locale/be-BY/imageZoom.dtd
+++ b/source/chrome/locale/be-BY/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Рэжым скролінга">
 <!ENTITY iz.options.scrollrelative.label "Relative">
 <!ENTITY iz.options.scrollabsolute.label "Абсалютна">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Індывідуальныя опцыі павелічэння">
 <!ENTITY iz.options.context.label "Кантэкстнае меню">
 <!ENTITY iz.options.contextdisplay.label "Адлюстраванне Кантэкстнага меню">

--- a/source/chrome/locale/ca-AD/imageZoom.dtd
+++ b/source/chrome/locale/ca-AD/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Mode de desplaçament">
 <!ENTITY iz.options.scrollrelative.label "Relatiu">
 <!ENTITY iz.options.scrollabsolute.label "Absolut">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Opcions de zoom individual">
 <!ENTITY iz.options.context.label "Menú contextual">
 <!ENTITY iz.options.contextdisplay.label "Opcions de visualització del menú contextual">

--- a/source/chrome/locale/cs-CZ/imageZoom.dtd
+++ b/source/chrome/locale/cs-CZ/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Scroll Mode">
 <!ENTITY iz.options.scrollrelative.label "Relative">
 <!ENTITY iz.options.scrollabsolute.label "Absolute">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Osobní nastavení měřítka">
 <!ENTITY iz.options.context.label "Místní nabídka">
 <!ENTITY iz.options.contextdisplay.label "Nastavení položek místní nabídky">

--- a/source/chrome/locale/de/imageZoom.dtd
+++ b/source/chrome/locale/de/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Scroll-Modus:">
 <!ENTITY iz.options.scrollrelative.label "Relativ">
 <!ENTITY iz.options.scrollabsolute.label "Absolut">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Zoom-Einstellungen für Einzelgrafiken">
 <!ENTITY iz.options.context.label "Kontextmenü">
 <!ENTITY iz.options.contextdisplay.label "Anzeigeoptionen für das Kontextmenü">

--- a/source/chrome/locale/en-US/imageZoom.dtd
+++ b/source/chrome/locale/en-US/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Scroll Mode">
 <!ENTITY iz.options.scrollrelative.label "Relative">
 <!ENTITY iz.options.scrollabsolute.label "Absolute">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Individual Zoom Options">
 <!ENTITY iz.options.misc.label "Miscellaneous Options">
 <!ENTITY iz.options.showStatus.label "Show Image Zoom status in the Status Bar">

--- a/source/chrome/locale/es-AR/imageZoom.dtd
+++ b/source/chrome/locale/es-AR/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Configuración de scroll">
 <!ENTITY iz.options.scrollrelative.label "Relativo">
 <!ENTITY iz.options.scrollabsolute.label "Absoluto">
+<!ENTITY iz.options.rotatekeys.label "Tecla de rotación">
+<!ENTITY iz.options.defaultrotate.label "Incremento de ángulo de rotación">
 <!ENTITY iz.options.singlezoom.label "Opciones de zoom individual">
 <!ENTITY iz.options.context.label "Menú contextual">
 <!ENTITY iz.options.contextdisplay.label "Opciones de visualización del menú contextual">

--- a/source/chrome/locale/es-ES/imageZoom.dtd
+++ b/source/chrome/locale/es-ES/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Configuración de scroll">
 <!ENTITY iz.options.scrollrelative.label "Relativo">
 <!ENTITY iz.options.scrollabsolute.label "Absoluto">
+<!ENTITY iz.options.rotatekeys.label "Tecla de rotación">
+<!ENTITY iz.options.defaultrotate.label "Incremento de ángulo de rotación">
 <!ENTITY iz.options.singlezoom.label "Opciones de zoom individual">
 <!ENTITY iz.options.context.label "Menú contextual">
 <!ENTITY iz.options.contextdisplay.label "Opciones de visualización del menú contextual">

--- a/source/chrome/locale/fa-IR/imageZoom.dtd
+++ b/source/chrome/locale/fa-IR/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Scroll Mode">
 <!ENTITY iz.options.scrollrelative.label "Relative">
 <!ENTITY iz.options.scrollabsolute.label "Absolute">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Individual Zoom Options">
 <!ENTITY iz.options.context.label "Context Menu">
 <!ENTITY iz.options.contextdisplay.label "Context Menu Display Options">

--- a/source/chrome/locale/fi-FI/imageZoom.dtd
+++ b/source/chrome/locale/fi-FI/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Vieritystapa">
 <!ENTITY iz.options.scrollrelative.label "Suhteellinen">
 <!ENTITY iz.options.scrollabsolute.label "Absoluuttinen">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Yksilölliset suurennusvalinnat">
 <!ENTITY iz.options.context.label "Kuvan suurennuksen pikavalikko">
 <!ENTITY iz.options.contextdisplay.label "Pikavalikossa näytettävät kohteet">

--- a/source/chrome/locale/fr/imageZoom.dtd
+++ b/source/chrome/locale/fr/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Mode défilement">
 <!ENTITY iz.options.scrollrelative.label "Relatif">
 <!ENTITY iz.options.scrollabsolute.label "Absolu">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Options de zoom individuelles">
 <!ENTITY iz.options.context.label "Menu contextuel">
 <!ENTITY iz.options.contextdisplay.label "Options d'affichage du menu contextuel">

--- a/source/chrome/locale/ga-IE/imageZoom.dtd
+++ b/source/chrome/locale/ga-IE/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Scroll Mode">
 <!ENTITY iz.options.scrollrelative.label "Relative">
 <!ENTITY iz.options.scrollabsolute.label "Absolute">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Individual Zoom Options">
 <!ENTITY iz.options.context.label "Context Menu">
 <!ENTITY iz.options.contextdisplay.label "Context Menu Display Options">

--- a/source/chrome/locale/he-IL/imageZoom.dtd
+++ b/source/chrome/locale/he-IL/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "מצב גלילה">
 <!ENTITY iz.options.scrollrelative.label "קשור">
 <!ENTITY iz.options.scrollabsolute.label "קבוע">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "אפשרויות זום בלעדיות">
 <!ENTITY iz.options.context.label "תפריט העכבר">
 <!ENTITY iz.options.contextdisplay.label "תפריט העכבר אפשרויות מראה">

--- a/source/chrome/locale/hr-HR/imageZoom.dtd
+++ b/source/chrome/locale/hr-HR/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Scroll Mode">
 <!ENTITY iz.options.scrollrelative.label "Relative">
 <!ENTITY iz.options.scrollabsolute.label "Absolute">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Individual Zoom Options">
 <!ENTITY iz.options.context.label "Context Menu">
 <!ENTITY iz.options.contextdisplay.label "Context Menu Display Options">

--- a/source/chrome/locale/hu-HU/imageZoom.dtd
+++ b/source/chrome/locale/hu-HU/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Görgetési mód">
 <!ENTITY iz.options.scrollrelative.label "Relatív">
 <!ENTITY iz.options.scrollabsolute.label "Abszolút">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Képek egyedi átméretezése">
 <!ENTITY iz.options.context.label "Helyzetérzékeny menü">
 <!ENTITY iz.options.contextdisplay.label "Kép helyzetérzékeny menü">

--- a/source/chrome/locale/it-IT/imageZoom.dtd
+++ b/source/chrome/locale/it-IT/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Modalità di scorrimento">
 <!ENTITY iz.options.scrollrelative.label "Relativa">
 <!ENTITY iz.options.scrollabsolute.label "Assoluta">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Opzione zoom singola immagine">
 <!ENTITY iz.options.context.label "Menu contestuale">
 <!ENTITY iz.options.contextdisplay.label "Opzioni di visualizzazione del menu contestuale">

--- a/source/chrome/locale/ja-JP/imageZoom.dtd
+++ b/source/chrome/locale/ja-JP/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "スクロール">
 <!ENTITY iz.options.scrollrelative.label "相対距離">
 <!ENTITY iz.options.scrollabsolute.label "絶対距離">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "画像の拡大 オプション">
 <!ENTITY iz.options.context.label "コンテキストメニュー">
 <!ENTITY iz.options.contextdisplay.label "コンテキストメニュー 表示オプション">

--- a/source/chrome/locale/ko-KR/imageZoom.dtd
+++ b/source/chrome/locale/ko-KR/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "스크롤 방식">
 <!ENTITY iz.options.scrollrelative.label "상대 스크롤">
 <!ENTITY iz.options.scrollabsolute.label "절대 스크롤">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "그림 확대 설정">
 <!ENTITY iz.options.context.label "문맥 메뉴">
 <!ENTITY iz.options.contextdisplay.label "문맥 메뉴에서 보여줄 항목">

--- a/source/chrome/locale/mk-MK/imageZoom.dtd
+++ b/source/chrome/locale/mk-MK/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Начин за тркалање">
 <!ENTITY iz.options.scrollrelative.label "релативен">
 <!ENTITY iz.options.scrollabsolute.label "апсолутен">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Засебни подесувања за зголемување">
 <!ENTITY iz.options.context.label "Контекстно мени">
 <!ENTITY iz.options.contextdisplay.label "Подесувања за приказ на контекстното мени">

--- a/source/chrome/locale/nl-NL/imageZoom.dtd
+++ b/source/chrome/locale/nl-NL/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Scroll mode">
 <!ENTITY iz.options.scrollrelative.label "relatief">
 <!ENTITY iz.options.scrollabsolute.label "absoluut">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Individuele zoom opties">
 <!ENTITY iz.options.context.label "Contextmenu">
 <!ENTITY iz.options.contextdisplay.label "Contextmenu opties weergeven">

--- a/source/chrome/locale/pl-PL/imageZoom.dtd
+++ b/source/chrome/locale/pl-PL/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Tryb przewijania">
 <!ENTITY iz.options.scrollrelative.label "Względne">
 <!ENTITY iz.options.scrollabsolute.label "Absolutne">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Osobiste opcje powiększania">
 <!ENTITY iz.options.context.label "Menu kontekstowe">
 <!ENTITY iz.options.contextdisplay.label "Menu kontekstowe - opcje">

--- a/source/chrome/locale/pt-BR/imageZoom.dtd
+++ b/source/chrome/locale/pt-BR/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Scroll Mode">
 <!ENTITY iz.options.scrollrelative.label "Relative">
 <!ENTITY iz.options.scrollabsolute.label "Absolute">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Opções de Zoom individual">
 <!ENTITY iz.options.context.label "Menu de Contexto">
 <!ENTITY iz.options.contextdisplay.label "Opções de Exibição do Menu de Contexo">

--- a/source/chrome/locale/ro-RO/imageZoom.dtd
+++ b/source/chrome/locale/ro-RO/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Modul de scalare:">
 <!ENTITY iz.options.scrollrelative.label "Relativ">
 <!ENTITY iz.options.scrollabsolute.label "Absolut">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Opțiuni pentru scalarea individuală">
 <!ENTITY iz.options.context.label "Meniu contextual">
 <!ENTITY iz.options.contextdisplay.label "Opțiunile meniului contextual">

--- a/source/chrome/locale/ru-RU/imageZoom.dtd
+++ b/source/chrome/locale/ru-RU/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Режим скроллинга">
 <!ENTITY iz.options.scrollrelative.label "Относительный">
 <!ENTITY iz.options.scrollabsolute.label "Абсолютный">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Индивидуальные параметры увеличения">
 <!ENTITY iz.options.context.label "Контекстное меню">
 <!ENTITY iz.options.contextdisplay.label "Отображение контекстного меню">

--- a/source/chrome/locale/sk-SK/imageZoom.dtd
+++ b/source/chrome/locale/sk-SK/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Režim rolovania">
 <!ENTITY iz.options.scrollrelative.label "Relatívne">
 <!ENTITY iz.options.scrollabsolute.label "Absolútne">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Osobné nastavenie rozmerov">
 <!ENTITY iz.options.context.label "Položky kontextovej ponuky">
 <!ENTITY iz.options.contextdisplay.label "Nastavenia položiek kontextovej ponuky">

--- a/source/chrome/locale/sl-SI/imageZoom.dtd
+++ b/source/chrome/locale/sl-SI/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Drsni način">
 <!ENTITY iz.options.scrollrelative.label "Relativno">
 <!ENTITY iz.options.scrollabsolute.label "Absolutno">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Možnosti posamezne povečave">
 <!ENTITY iz.options.context.label "Kontekstni meni">
 <!ENTITY iz.options.contextdisplay.label "Možnosti prikaza v kontekstnem meniju">

--- a/source/chrome/locale/sq-AL/imageZoom.dtd
+++ b/source/chrome/locale/sq-AL/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Scroll Mode">
 <!ENTITY iz.options.scrollrelative.label "Relativ">
 <!ENTITY iz.options.scrollabsolute.label "Absolut">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Mundësitë Individuale të Rritjes">
 <!ENTITY iz.options.context.label "Menyja Kontekstuale">
 <!ENTITY iz.options.contextdisplay.label "Context Menu Display Options">

--- a/source/chrome/locale/sv-SE/imageZoom.dtd
+++ b/source/chrome/locale/sv-SE/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Rullmetod">
 <!ENTITY iz.options.scrollrelative.label "Relativ">
 <!ENTITY iz.options.scrollabsolute.label "Absolut">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Individuella zoomalternativ">
 <!ENTITY iz.options.context.label "Meny vid högerklick">
 <!ENTITY iz.options.contextdisplay.label "Visningsalternativ högerklicksmeny">

--- a/source/chrome/locale/tr-TR/imageZoom.dtd
+++ b/source/chrome/locale/tr-TR/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Tekerlek modu">
 <!ENTITY iz.options.scrollrelative.label "Nisbi">
 <!ENTITY iz.options.scrollabsolute.label "Kesin">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Tek resmi yakınlaştırma seçenekleri">
 <!ENTITY iz.options.context.label "Açılır menü">
 <!ENTITY iz.options.contextdisplay.label "Açılır Menü Görünüm Seçenekleri">

--- a/source/chrome/locale/uk-UA/imageZoom.dtd
+++ b/source/chrome/locale/uk-UA/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Режим прокрутки">
 <!ENTITY iz.options.scrollrelative.label "Відносний">
 <!ENTITY iz.options.scrollabsolute.label "Абсолютний">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Індивідуальні опції збільшення">
 <!ENTITY iz.options.context.label "Контекстне меню">
 <!ENTITY iz.options.contextdisplay.label "Відображення Контекстного меню">

--- a/source/chrome/locale/vi-VN/imageZoom.dtd
+++ b/source/chrome/locale/vi-VN/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "Scroll Mode">
 <!ENTITY iz.options.scrollrelative.label "Relative">
 <!ENTITY iz.options.scrollabsolute.label "Absolute">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "Individual Zoom Options">
 <!ENTITY iz.options.context.label "Context Menu">
 <!ENTITY iz.options.contextdisplay.label "Context Menu Display Options">

--- a/source/chrome/locale/zh-CN/imageZoom.dtd
+++ b/source/chrome/locale/zh-CN/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "滚轮模式">
 <!ENTITY iz.options.scrollrelative.label "相对滚动">
 <!ENTITY iz.options.scrollabsolute.label "绝对滚动">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "单一缩放选项">
 <!ENTITY iz.options.context.label "右健菜单">
 <!ENTITY iz.options.contextdisplay.label "右健菜单显示选项">

--- a/source/chrome/locale/zh-TW/imageZoom.dtd
+++ b/source/chrome/locale/zh-TW/imageZoom.dtd
@@ -23,6 +23,8 @@
 <!ENTITY iz.options.scrollmode.label "滾動模式">
 <!ENTITY iz.options.scrollrelative.label "相對定位">
 <!ENTITY iz.options.scrollabsolute.label "絕對定位">
+<!ENTITY iz.options.rotatekeys.label "Rotate Key">
+<!ENTITY iz.options.defaultrotate.label "Rotate Angle Increments">
 <!ENTITY iz.options.singlezoom.label "個別縮放選項">
 <!ENTITY iz.options.context.label "快顯功能表">
 <!ENTITY iz.options.contextdisplay.label "快顯功能表選項">

--- a/source/defaults/preferences/imagezoom-defaults.js
+++ b/source/defaults/preferences/imagezoom-defaults.js
@@ -32,4 +32,6 @@ pref("extensions.imagezoom.version", "0.0.0");
 pref("extensions.imagezoom.reversescrollzoom", false);
 pref("extensions.imagezoom.toggleFitReset", false);
 pref("extensions.imagezoom.showStatus", false);
+pref("extensions.imagezoom.rotateKeys", 2);
+pref("extensions.imagezoom.rotateValue", 90);
 pref("extensions.{1A2D0EC4-75F5-4c91-89C4-3656F6E44B68}.description", "chrome://net.yellowgorilla.imagezoom/locale/imagezoom.properties");


### PR DESCRIPTION
I've been using a modified version of 0.4.6 for a long time, so I decided to polish my additions and add them to the official version :smiley: 
- The "image reset" function now toggles between the original size and the natural size
- Fixed rotation for arbitrary angles (only multiples of 90° were working properly)
- Added the ability to rotate an image using the scroll wheel + a modifier key
  - Added the options in the GUI to select the modifier key(s) and the angle increment
  - Added the english label for those options to every locale, except for spanish, which are translated
