### PR TITLE
Squash frequent console errors: "TypeError: document.popupNode is null"

### DIFF
--- a/source/chrome/content/overlay.js
+++ b/source/chrome/content/overlay.js
@@ -198,7 +198,8 @@ function ImageZoomOverlay() {
   }
 
   function disableContextMenu(event) {
-    if (document.popupNode.tagName.toLowerCase() == "img" || document.popupNode.tagName.toLowerCase() == "canvas") {
+    if (document.popupNode && (document.popupNode.tagName.toLowerCase() == "img"
+                               || document.popupNode.tagName.toLowerCase() == "canvas")) {
       izContentVariables().linuxImage = document.popupNode;
       izContext = event.originalTarget;
       event.preventDefault();


### PR DESCRIPTION
I was seeing frequent errors on the console, when imagezoom attempts to access properties of document.popupNode without first checking its existence. This fix clears up those messages.
